### PR TITLE
Handle compiler warnings

### DIFF
--- a/Sony9PinRemote.h
+++ b/Sony9PinRemote.h
@@ -146,6 +146,7 @@ public:
                                 }
                             }
                         }
+                        // Fallthrough
                         case Cmd1::SENSE_RETURN: {
                             if (decoder.cmd2() == SenseReturn::STATUS_DATA) {
                                 // decode status based on requested range by `status_sense()`

--- a/Sony9PinRemote/Decoder.h
+++ b/Sony9PinRemote/Decoder.h
@@ -685,7 +685,7 @@ private:
     inline auto from_bcd_to_dec(const T& n) const
         -> typename std::enable_if<std::is_integral<T>::value, size_t>::type {
         return n - 6 * (n >> 4);
-    };
+    }
 
     bool empty() const {
         return curr_size == 0;

--- a/Sony9PinRemote/Types.h
+++ b/Sony9PinRemote/Types.h
@@ -349,6 +349,10 @@ struct Errors {
     bool b_buffer_overrun;
     bool b_framing_error;
     bool b_timeout;
+
+    Errors() {
+        memset(this, 0, sizeof(Errors));
+    }
 };
 
 struct Status {
@@ -421,6 +425,10 @@ struct Status {
     bool b_rec_inhib;
     // byte 9
     bool b_fnc_abort;
+
+    Status() {
+        memset(this, 0, sizeof(Status));
+    }
 };
 
 struct TimeCode {

--- a/Sony9PinRemote/util/ArxTypeTraits/ArxTypeTraits/type_traits.h
+++ b/Sony9PinRemote/util/ArxTypeTraits/ArxTypeTraits/type_traits.h
@@ -602,7 +602,7 @@ namespace arx { // others
                 return static_cast<function_type>(f);
             }
         };
-    };
+    }
     template <typename T>
     struct function_traits : public function_traits<decltype(&T::operator())> {};
     template <typename class_type, typename ret, typename ... arguments>


### PR DESCRIPTION
Handle some warnings from different compilers.
Note that "[[fallthrough]]" was not used because no C++17 features is used up to now so I preferred not to break the C++14 compatibility. And not sure if fall through was intended.

GCC with `-Wpedantic` and default `-Wimplicit-fallthrough`:
```
g++ -c -pipe -Wpedaantic -Wall -O2 -std=gnu++1y -Wall -W -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_GUI_LIB -DQT_SERIALPORT_LIB -DQT_CORE_LIB -I. -I. -I../../.. -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtSerialPort -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -I. -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o sony9pin.o sony9pin.cpp
In file included from ../../../Sony9PinRemote/Sony9PinRemote/util/ArxTypeTraits/ArxTypeTraits.h:40,
                 from ../../../Sony9PinRemote/Sony9PinRemote/Encoder.h:6,
                 from ../../../Sony9PinRemote/Sony9PinRemote.h:14,
                 from sony9pin.cpp:8:
../../../Sony9PinRemote/Sony9PinRemote/util/ArxTypeTraits/ArxTypeTraits/type_traits.h:605:6: warning: extra ‘;’ [-Wpedantic]
  605 |     };
      |      ^
In file included from ../../../Sony9PinRemote/Sony9PinRemote.h:15,
                 from sony9pin.cpp:8:
../../../Sony9PinRemote/Sony9PinRemote/Decoder.h:688:6: warning: extra ‘;’ [-Wpedantic]
  688 |     };
      |      ^
      |      -
In file included from sony9pin.cpp:8:
../../../Sony9PinRemote/Sony9PinRemote.h: In member function ‘bool sony9pin::Controller::parse()’:
../../../Sony9PinRemote/Sony9PinRemote.h:137:29: warning: this statement may fall through [-Wimplicit-fallthrough=]
  137 |                             switch (decoder.cmd2()) {
      |                             ^~~~~~
../../../Sony9PinRemote/Sony9PinRemote.h:149:25: note: here
  149 |                         case Cmd1::SENSE_RETURN: {
      |                         ^~~~
g++ -Wl,-O1 -o sony9pin sony9pin.o   /usr/lib/x86_64-linux-gnu/libQt5Gui.so /usr/lib/x86_64-linux-gnu/libQt5SerialPort.so /usr/lib/x86_64-linux-gnu/libQt5Core.so /usr/lib/x86_64-linux-gnu/libGL.so -lpthread
```

Visual C++ (note that `type_traits.h` does not compile as is with this compiler, I comment some parts and it is fine with this project, but at least it spots some risks with the current code):
```
sony9pinremote\decoder.h(171): error C4700: uninitialized local variable 'errs' used
sony9pinremote\decoder.h(557): error C4700: uninitialized local variable 'sts' used
```